### PR TITLE
[feature] Add blog section with FAR.AI workshop post

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>Blog - Kyungeun Lim</title>
+
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="static/css/bootstrap.css">
+
+    <style>
+      .panel-body {
+        font-size: 16px;
+        line-height: 1.6;
+      }
+
+      .panel-body .lead {
+        font-size: 22px;
+        line-height: 1.5;
+      }
+
+      .panel-body ul li {
+        font-size: 16px;
+      }
+
+      .panel-body h4 {
+        font-size: 18px;
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div>
+        <div id="navbar" class="collapse navbar-collapse">
+          <ul class="nav navbar-nav">
+            <li><a href="index.html">About</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li class="active"><a href="blog.html">Blog</a></li>
+          </ul>
+        </div><!--/.nav-collapse -->
+      </div>
+    </nav>
+
+<br><br>
+
+    <div class="container">
+
+      <div class="starter-template">
+        <h1>Blog</h1>
+        <p class="lead">Personal reflections, field reports, and experience sharing.</p>
+      </div>
+
+      <!-- Blog Posts -->
+      <div class="row">
+
+	<!-- FAR.AI Workshop Post -->
+	<div class="col-md-12">
+	  <div class="panel panel-default">
+	    <div class="panel-heading" style="display: flex; justify-content: space-between; align-items: center;">
+	      <h3 class="panel-title" style="margin: 0;">My First AI Safety Workshop: FAR.AI London Alignment Workshop</h3>
+	      <small class="text-muted">March 2026</small>
+	    </div>
+	    <div class="panel-body">
+              <p>A newcomer's experience attending a two-day alignment research workshop — the selectivity, the networking, and what I learned from concentrated conversations with researchers in the field.</p>
+
+              <a href="far_ai_workshop.html" class="btn btn-primary">Read More</a>
+	    </div>
+	  </div>
+	</div>
+
+      </div> <!-- End row -->
+
+      <div class="starter-template">
+        <hr>
+        <p class="text-center">
+          Find me on
+          <a href="https://www.linkedin.com/in/kyungeun-lim" target="_blank">LinkedIn</a> |
+          <a href="https://github.com/kyungeunlim" target="_blank">GitHub</a> |
+          <a href="https://scholar.google.com/citations?user=bGdDHjcAAAAJ&hl=en" target="_blank">Google Scholar</a>
+        </p>
+      </div>
+
+<script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
+<script src="static/js/bootstrap.min.js"></script>
+
+    </div><!-- /.container -->
+
+    <!-- Bootstrap core JavaScript -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="static/js/bootstrap.min.js"></script>
+
+  </body>
+</html>

--- a/far_ai_workshop.html
+++ b/far_ai_workshop.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Attending the FAR.AI London Alignment Workshop as a newcomer to AI safety">
+    <meta name="author" content="Kyungeun Lim">
+
+    <title>My First AI Safety Workshop: FAR.AI London Alignment Workshop</title>
+
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="static/css/bootstrap.css">
+
+    <style>
+      .section-header {
+        margin-top: 40px;
+        margin-bottom: 20px;
+        padding-bottom: 10px;
+        border-bottom: 2px solid #337ab7;
+      }
+      .subsection {
+        margin-top: 25px;
+        margin-bottom: 15px;
+      }
+      .subsection ul li {
+	  font-size: 16px;
+	  line-height: 1.6;
+	  margin-bottom: 8px;
+      }
+      .subsection h3 {
+          font-size: 24px;
+	  color: #2c5282;
+          margin-bottom: 15px;
+      }
+      .subsection h4 {
+         font-size: 20px;
+	 color: #555555;
+      }
+      .subsection p, .container p {
+        font-size: 16px;
+        line-height: 1.6;
+        margin-bottom: 12px;
+      }
+      .lead {
+        font-size: 22px;
+        line-height: 1.5;
+      }
+      strong {
+        color: #2c5282;
+      }
+      .disclaimer-box {
+        background-color: #f8f9fa;
+        border-left: 4px solid #337ab7;
+        padding: 15px;
+        margin: 20px 0;
+      }
+    </style>
+</head>
+
+<body>
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div>
+        <div id="navbar" class="collapse navbar-collapse">
+          <ul class="nav navbar-nav">
+            <li><a href="index.html">About</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li class="active"><a href="blog.html">Blog</a></li>
+          </ul>
+        </div><!--/.nav-collapse -->
+      </div>
+    </nav>
+
+    <br><br><br>
+
+    <div class="container">
+
+<!-- Header -->
+<div class="starter-template">
+  <h1>My First AI Safety Workshop: FAR.AI London Alignment Workshop</h1>
+  <p class="lead">A newcomer's experience attending a two-day alignment research workshop, and what I learned from it.</p>
+  <p class="text-muted">March 2026</p>
+</div>
+
+<!-- Disclaimer -->
+<div class="disclaimer-box">
+  <p><strong>Epistemic humility note:</strong> I'm relatively new to AI safety. I joined the field through the <a href="https://erafellowship.org/" target="_blank">Cambridge ERA:AI Safety Fellowship</a> and this was my first workshop in this space. What follows is a personal account of my experience — not expert commentary. I may misunderstand nuances that veterans take for granted, and my impressions are shaped by a sample size of one workshop. I'm writing this in the spirit of Substack-style experience sharing: a low bar, first-person account that might be useful to others considering entering the field or attending similar events.</p>
+</div>
+
+<!-- Getting In -->
+<div class="section-header">
+  <h2>The Bar to Attend Was Higher Than I Expected</h2>
+</div>
+
+<div class="subsection">
+  <p>The <a href="https://www.far.ai/events/event-list/london-alignment-workshop-2026" target="_blank">FAR.AI London Alignment Workshop</a> took place on March 2-3, 2026. It's part of a series of alignment workshops that FAR.AI has organized in cities including San Diego, Singapore, Vienna, New Orleans, and San Francisco.</p>
+
+  <p>My first surprise was how selective the process was. The application required an Expression of Interest that asked for a summary of who you are (previous experience and interest in alignment work), your goals for attending (questions you'd like answered or progress you'd like to make), and who you'd like to connect with at the event. The ERA:AI fellowship itself has an acceptance rate of less than 1%, but even among fellows, roughly 15% of those who applied were invited to attend. I know of about 4 fellows from my cohort who were invited. So the bar to even be in the room was quite high, which shaped the experience in ways I didn't fully anticipate.</p>
+</div>
+
+<!-- SwapCard and Networking -->
+<div class="section-header">
+  <h2>SwapCard Made Networking Easy</h2>
+</div>
+
+<div class="subsection">
+  <p>The organizers strongly encouraged using an app called SwapCard, which listed all attendees and made it easy to see who was there and schedule 1:1 meetings. Even before the workshop started, I was already getting invitations for 1:1s from other attendees. I ended up scheduling 3-4 per day.</p>
+
+  <p>But the scheduled meetings were just the starting point. Conversations happened organically too — over coffee, over meals, by joining someone else's 1:1 when topics overlapped. By the end, I'd had far more conversations than I had planned.</p>
+
+  <p>What surprised me was how willing people were to engage with a newcomer. I think the selectivity of the workshop helped here — everyone had already passed a certain bar, so there was a baseline level of trust. Many attendees seemed genuinely curiosity-driven and eager to talk about research interests, regardless of seniority. The community felt friendlier and more approachable than I expected, and the combination of high selectivity and good facilitation through SwapCard probably contributed to that.</p>
+</div>
+
+<!-- Talks -->
+<div class="section-header">
+  <h2>Talks as Rapid Immersion</h2>
+</div>
+
+<div class="subsection">
+  <p>The talk quality was high across the board. The opening and keynotes were strong, but I was also impressed by the shorter ~10-minute talks — they were dense and well-prepared. For a newcomer, these served as a rapid survey of what's going on in the field. I found myself learning new terminology quickly just by being exposed to many talks in sequence.</p>
+
+  <p>I also attended a discussion group on interpretability later in the day, which helped me go deeper on the area most relevant to my own research.</p>
+</div>
+
+<!-- Research Sharpening -->
+<div class="section-header">
+  <h2>Sharpening My Research Through Conversation</h2>
+</div>
+
+<div class="subsection">
+  <h3>Practicing the Elevator Pitch</h3>
+  <p>Having so many 1:1s meant I got to explain my ERA project — developing evaluation metrics for machine unlearning methods — many times over two days. Each time, my description got a little more refined. By the end, I could articulate what I was doing and why it mattered more clearly than when I arrived.</p>
+
+  <h3>Asking the Same Question to Many People</h3>
+  <p>I had a specific question going in. My project involves evaluating whether unlearning methods truly remove dangerous knowledge from a model or merely suppress it at the output level. Current behavioral metrics (which measure model responses) can't distinguish between the two. So I'm interested in looking at model internals to find structural metrics that can.</p>
+
+  <p>This led me to a question I asked many people: why are activation-based approaches to studying model internals more prevalent in the field, when activations are input-dependent and potentially confounding? Weight-based approaches (like SVD-based metrics) seem like they'd suffer less from this issue. What are the tradeoffs?</p>
+
+  <p>The responses were varied and helpful. Some researchers had a clear preference for activation-based methods. Others acknowledged the tradeoffs of both approaches and asked me back: what is the specific research question I'm trying to answer? That question — turned back on me — was more useful than any direct answer. It helped me think more carefully about what I actually need from a metric, rather than picking an approach first.</p>
+
+  <p>This is a genuinely open question in the field. Both approaches have their limitations, and the right choice depends on what you're trying to measure. Having many people push back on my assumptions from different angles over two days helped me refine my thinking more than I could have done alone in the same time.</p>
+
+  <h3>Getting Pointed to the Right People</h3>
+  <p>In two separate 1:1s, different people independently suggested I talk to the same person because his work overlapped closely with mine. When I did, it was immediately productive — he had thought about the problem longer than I had, acknowledged that both SVD-based and activation-based approaches have their own limitations, and gave me feedback as if he were reviewing my project as a paper. That kind of targeted, expert feedback is hard to find outside of a setting like this.</p>
+
+  <h3>Finding a Possible Collaborator</h3>
+  <p>Over a coffee break, I met a researcher who, after hearing about my work, shared a paper she was working on and suggested I reach out after the fellowship for a possible collaboration. This was entirely organic — not something I went in looking for.</p>
+</div>
+
+<!-- Complexity Regime -->
+<div class="section-header">
+  <h2>Entering a Different Complexity Regime</h2>
+</div>
+
+<div class="subsection">
+  <p>One realization that crystallized through the workshop conversations: I'm entering a fundamentally different complexity regime from what I've worked with before.</p>
+
+  <p>In my physics research and industry ML work, the data I dealt with was mostly scalar. I worked with models like XGBoost, GAMs, and LSTMs — not simple, but their interpretability doesn't require navigating very high-dimensional spaces in the same way. I have solid experience in data analysis with statistics, and making sense of those models was manageable.</p>
+
+  <p>But with transformer-based architectures, the complexity increases by orders of magnitude. Model weights live in very high-dimensional spaces and are sensitive to data and hyperparameters. Even finding a clean, controlled setup where you can make causal claims is hard. This isn't just "harder" — it's a qualitatively different kind of problem. Talking with many people at the workshop accelerated this realization and gave me a better sense of where the real difficulties lie.</p>
+</div>
+
+<!-- Closing -->
+<div class="section-header">
+  <h2>Overall Impressions</h2>
+</div>
+
+<div class="subsection">
+  <p>If I had to summarize: the talks gave me a rapid survey of the field, but the conversations were where the real value was. Two days of concentrated 1:1s with researchers who have thought about these problems longer than I have compressed a lot of learning into a short time.</p>
+
+  <p>The community was more approachable than I expected. People seemed genuinely interested in exchanging ideas, and the workshop structure — the selectivity, SwapCard, the meals, the discussion groups — was designed to make that happen.</p>
+
+  <p>I reposted a post from FAR.AI on day 1 of the workshop on LinkedIn — I hardly ever post there — noting that it was my first AI safety workshop and a sign that my career transition effort is going somewhere. It got more attention than I expected, including a comment from FAR.AI saying they hope to see me at future events. A small thing, but a nice signal of a welcoming community.</p>
+
+  <p>I came away with a sharper understanding of my own project, a better grasp of the field's open questions, several new connections, and a possible future collaborator. For a first workshop in a new field, that felt like a good outcome.</p>
+</div>
+
+<!-- Footer -->
+<div class="starter-template">
+  <hr>
+  <p class="text-center">
+    <a href="#" class="btn btn-default">
+      <span class="glyphicon glyphicon-arrow-up"></span> Back to Top
+    </a>
+  </p>
+  <p class="text-center">
+    Find me on
+    <a href="https://www.linkedin.com/in/kyungeun-lim" target="_blank">LinkedIn</a> |
+    <a href="https://github.com/kyungeunlim" target="_blank">GitHub</a> |
+    <a href="https://scholar.google.com/citations?user=bGdDHjcAAAAJ&hl=en" target="_blank">Google Scholar</a>
+  </p>
+</div>
+
+    </div><!-- /.container -->
+
+    <!-- Bootstrap core JavaScript -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="static/js/bootstrap.min.js"></script>
+
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,8 @@
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
             <li class="active"><a href="index.html">About</a></li>
-            <li><a href="projects.html">Projects</a></li> 
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="blog.html">Blog</a></li>
             <!--<li><a href="/projects">Projects</a></li>-->
           </ul>
         </div><!--/.nav-collapse -->

--- a/projects.html
+++ b/projects.html
@@ -49,8 +49,9 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="index.html">About</a></li> 
-            <li class="active"><a href="projects.html">Projects</a></li> 
+            <li><a href="index.html">About</a></li>
+            <li class="active"><a href="projects.html">Projects</a></li>
+            <li><a href="blog.html">Blog</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/transformer.html
+++ b/transformer.html
@@ -100,8 +100,9 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="index.html">About</a></li> 
-            <li class="active"><a href="projects.html">Projects</a></li> 
+            <li><a href="index.html">About</a></li>
+            <li class="active"><a href="projects.html">Projects</a></li>
+            <li><a href="blog.html">Blog</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/wave_machine.html
+++ b/wave_machine.html
@@ -30,8 +30,9 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="index.html">About</a></li> 
-            <li class="active"><a href="projects.html">Projects</a></li> 
+            <li><a href="index.html">About</a></li>
+            <li class="active"><a href="projects.html">Projects</a></li>
+            <li><a href="blog.html">Blog</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>


### PR DESCRIPTION
## Context
First blog post on the site — a personal experience report from attending the FAR.AI London Alignment Workshop (March 2-3, 2026).

## Changes
- Add `far_ai_workshop.html` — blog post about attending the workshop as a newcomer to AI safety
- Add `blog.html` — blog listing page (styled consistently with projects.html)
- Add "Blog" nav tab to all existing pages (index, projects, transformer, wave_machine)